### PR TITLE
feat: Update library with new functions

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -10,6 +10,8 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     container: openresty/openresty:1.21.4.1-0-focal
+    env:
+      GITHUB_TOKEN: unneeded
     steps:
       - name: Install git
         run: apt-get update && apt-get install -y git
@@ -32,3 +34,16 @@ jobs:
         with:
           name: lua-resty-aws-signature-${{ steps.svu.outputs.version }}.tar.gz
           path: lua-resty-aws-signature-${{ steps.svu.outputs.version }}.tar.gz
+  test:
+    name: Test
+    runs-on: ubuntu-22.04
+    container: openresty/openresty:1.21.4.1-0-focal
+    env:
+      LC_ALL: C
+      LANG: C
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up test dependencies
+        run: apt-get update && apt-get install -y cpanminus locales && cpanm Test::Nginx --notest
+      - name: Test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,18 @@ endif
 # Unit / functional testing
 ###############################################################
 
+# OPM doesn't currently have a native function to do local installs
+# So we have to hack it ourselves
+# See: https://github.com/openresty/opm/issues/39
+install_locally:
+	opm install openresty/lua-resty-string
+	opm install jkeys089/lua-resty-hmac
+	cp lib/resty/* /usr/local/openresty/lualib/resty/
+
 TEST_FILES = $(wildcard t/*.t)
 
-test: $(TEST_FILES)
-	prove $^
+test: install_locally
+	prove $(TEST_FILES)
 
 
 ###############################################################

--- a/lib/resty/aws-signature.lua
+++ b/lib/resty/aws-signature.lua
@@ -1,4 +1,5 @@
 --[[
+Copyright 2024 Adrian Astley (RichieSams)
 Copyright 2018 JobTeaser
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +21,15 @@ local str = require('resty.string')
 
 local _M = {}
 
+
+---------------------------------
+--- Helper functions
+---------------------------------
+
+---@alias Credentials {access_key:string, secret_key:string}
+
+---Fetches the AWS credentials from ENV variables and returns them in a table
+---@return Credentials
 local function get_credentials()
   local access_key = os.getenv('AWS_ACCESS_KEY_ID')
   local secret_key = os.getenv('AWS_SECRET_ACCESS_KEY')
@@ -30,14 +40,26 @@ local function get_credentials()
   }
 end
 
+---Formats the given timestamp in ISO 8601
+---@param timestamp integer The Unix timestamp to format
+---@return string
 local function get_iso8601_basic(timestamp)
-  return os.date('!%Y%m%dT%H%M%SZ', timestamp)
+  return tostring(os.date('!%Y%m%dT%H%M%SZ', timestamp))
 end
 
+---Formats the given timestamp in ISO 8601 shortened
+---@param  timestamp integer The timestamp in Unix Epoch seconds to format
+---@return           string
 local function get_iso8601_basic_short(timestamp)
-  return os.date('!%Y%m%d', timestamp)
+  return tostring(os.date('!%Y%m%d', timestamp))
 end
 
+---Calculates and returns the Derived Signing Key
+---@param  keys      Credentials Credentials returned from get_credentials()
+---@param  timestamp integer     The time as a Unix timestamp
+---@param  region    string      The AWS region the request will use
+---@param  service   string      The AWS service the request will use
+---@return           string
 local function get_derived_signing_key(keys, timestamp, region, service)
   local h_date = resty_hmac:new('AWS4' .. keys['secret_key'], resty_hmac.ALGOS.SHA256)
   h_date:update(get_iso8601_basic_short(timestamp))
@@ -56,6 +78,13 @@ local function get_derived_signing_key(keys, timestamp, region, service)
   return h:final()
 end
 
+---Calculates and returns the credential scope
+---
+---See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#create-string-to-sign
+---@param  timestamp integer The time as a Unix timestamp
+---@param  region    string  The AWS region the request will use
+---@param  service   string  The AWS service the request will use
+---@return           string
 local function get_cred_scope(timestamp, region, service)
   return get_iso8601_basic_short(timestamp)
       .. '/' .. region
@@ -63,86 +92,180 @@ local function get_cred_scope(timestamp, region, service)
       .. '/aws4_request'
 end
 
+---Returns the list of headers that we are signing, concatenated with semicolons
+---
+---See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#create-canonical-request
+---@return string
 local function get_signed_headers()
   return 'host;x-amz-content-sha256;x-amz-date'
 end
 
+---Returns The SHA256 hex-encoded digest of the request body of the input
+---@param  s string The input to hash
+---@return   string
 local function get_sha256_digest(s)
   local h = resty_sha256:new()
   h:update(s or '')
   return str.to_hex(h:final())
 end
 
-local function get_hashed_canonical_request(timestamp, host, uri)
-  local digest = get_sha256_digest(ngx.var.request_body)
+---Calculates the SHA256 hashed canonical request.
+---
+---See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#create-canonical-request
+---@param  timestamp   integer The current time in Unix Epoch seconds
+---@param  host        string  The upstream host
+---@param  uri         string  The path portion of the request URI
+---@param  body_digest string  The SHA256 hex-encoded digest of the request body
+---@return             string
+local function get_hashed_canonical_request(timestamp, host, uri, body_digest)
   local canonical_request = ngx.var.request_method .. '\n'
       .. uri .. '\n'
       .. '\n'
       .. 'host:' .. host .. '\n'
-      .. 'x-amz-content-sha256:' .. digest .. '\n'
+      .. 'x-amz-content-sha256:' .. body_digest .. '\n'
       .. 'x-amz-date:' .. get_iso8601_basic(timestamp) .. '\n'
       .. '\n'
       .. get_signed_headers() .. '\n'
-      .. digest
+      .. body_digest
   return get_sha256_digest(canonical_request)
 end
 
-local function get_string_to_sign(timestamp, region, service, host, uri)
+---Calculates and returns the "string to sign"
+---
+---See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#create-string-to-sign
+---@param  timestamp   integer The current time in Unix Epoch seconds
+---@param  region      string  The AWS region the request will use
+---@param  service     string  The AWS service the request will use
+---@param  host        string  The upstream host
+---@param  uri         string  The path portion of the request URI
+---@param  body_digest string  The SHA256 hex-encoded digest of the request body
+---@return             string
+local function get_string_to_sign(timestamp, region, service, host, uri, body_digest)
   return 'AWS4-HMAC-SHA256\n'
       .. get_iso8601_basic(timestamp) .. '\n'
       .. get_cred_scope(timestamp, region, service) .. '\n'
-      .. get_hashed_canonical_request(timestamp, host, uri)
+      .. get_hashed_canonical_request(timestamp, host, uri, body_digest)
 end
 
+---Signs the given string using the given key with the HMAC SHA256 algorithm
+---
+---See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#calculate-signature
+---@param derived_signing_key string The signing key
+---@param string_to_sign      string The string to sign
+---@return                    string
 local function get_signature(derived_signing_key, string_to_sign)
   local h = resty_hmac:new(derived_signing_key, resty_hmac.ALGOS.SHA256)
   h:update(string_to_sign)
   return h:final(nil, true)
 end
 
-local function get_authorization(keys, timestamp, region, service, host, uri)
+---Calculates and returns the appropriate value for the Authorization header
+---
+---See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#add-signature-to-request
+---@param  keys        Credentials Credentials returned from get_credentials()
+---@param  timestamp   integer     The current time in Unix Epoch seconds
+---@param  region      string      The AWS region the request will use
+---@param  service     string      The AWS service the request will use
+---@param  host        string      The upstream host
+---@param  uri         string      The path portion of the request URI
+---@param  body_digest string      The SHA256 hex-encoded digest of the request body
+---@return             string
+local function get_authorization(keys, timestamp, region, service, host, uri, body_digest)
   local derived_signing_key = get_derived_signing_key(keys, timestamp, region, service)
-  local string_to_sign = get_string_to_sign(timestamp, region, service, host, uri)
+  local string_to_sign = get_string_to_sign(timestamp, region, service, host, uri, body_digest)
   local auth = 'AWS4-HMAC-SHA256 '
       .. 'Credential=' .. keys['access_key'] .. '/' .. get_cred_scope(timestamp, region, service)
-      .. ', SignedHeaders=' .. get_signed_headers()
-      .. ', Signature=' .. get_signature(derived_signing_key, string_to_sign)
+      .. ',SignedHeaders=' .. get_signed_headers()
+      .. ',Signature=' .. get_signature(derived_signing_key, string_to_sign)
   return auth
 end
 
-local function get_service_and_region(host)
-  local patterns = {
-    { 's3.amazonaws.com',                 's3', 'us-east-1' },
-    { 's3-external-1.amazonaws.com',      's3', 'us-east-1' },
-    { 's3%-([a-z0-9-]+)%.amazonaws%.com', 's3', nil }
-  }
 
-  for _, data in ipairs(patterns) do
-    local region = host:match(data[1])
-    if region ~= nil and data[3] == nil then
-      return data[2], region
-    elseif region ~= nil then
-      return data[2], data[3]
-    end
-  end
+---------------------------------
+--- Exported module functions
+---------------------------------
 
-  return nil, nil
+---Calculates and sets the approriate request headers for an authenticated AWS request
+---
+---This function will read and hash the entire request body to add it to the authentication
+---signature. If you want to avoid this overhead, you can use aws_set_headers_unsigned_body()
+---
+---Note: This function requires the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
+---      variables to be set. You must expose them to LUA in your nginx.conf using:
+---
+--- ```
+--- env AWS_ACCESS_KEY_ID;
+--- env AWS_SECRET_ACCESS_KEY;
+--- ```
+---
+---See: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
+---@param host    string The upstream host
+---@param uri     string The path portion of the request URI
+---@param region  string The AWS region the request will use
+---@param service string The AWS service the request will use
+function _M.aws_set_headers(host, uri, region, service)
+  local body_digest = get_sha256_digest(ngx.var.request_body)
+  local timestamp = tonumber(ngx.time())
+
+  _M.aws_set_headers_detailed(host, uri, region, service, body_digest, timestamp)
 end
 
-function _M.aws_set_headers(host, uri)
-  local creds = get_credentials()
+---Calculates and sets the approriate request headers for an authenticated AWS request
+---
+---This function will skip the request body digest calculation. Which saves the cost and
+---time of reading / hashing the entire request body. If you do want the request body digest
+---to be part of the signature though, you can use aws_set_headers() instead
+---
+---Note: This function requires the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
+---      variables to be set. You must expose them to LUA in your nginx.conf using:
+---
+--- ```
+--- env AWS_ACCESS_KEY_ID;
+--- env AWS_SECRET_ACCESS_KEY;
+--- ```
+---
+---See: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
+---@param host    string The upstream host
+---@param uri     string The path portion of the request URI
+---@param region  string The AWS region the request will use
+---@param service string The AWS service the request will use
+function _M.aws_set_headers_unsigned_body(host, uri, region, service)
+  local body_digest = 'UNSIGNED-PAYLOAD'
   local timestamp = tonumber(ngx.time())
-  local service, region = get_service_and_region(host)
-  local auth = get_authorization(creds, timestamp, region, service, host, uri)
+
+  _M.aws_set_headers_detailed(host, uri, region, service, body_digest, timestamp)
+end
+
+---Calculates and sets the approriate request headers for an authenticated AWS request
+---
+---This function is identical to aws_set_headers(), but it allows you to set the body_digest
+---and timestamp yourself. Unless you are doing something very special, you should generally
+---just use aws_set_headers() or aws_set_headers_unsigned_body()
+---
+---Note: This function requires the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
+---      variables to be set. You must expose them to LUA in your nginx.conf using:
+---
+--- ```
+--- env AWS_ACCESS_KEY_ID;
+--- env AWS_SECRET_ACCESS_KEY;
+--- ```
+---
+---See: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
+---@param host        string  The upstream host
+---@param uri         string  The path portion of the request URI
+---@param region      string  The AWS region the request will use
+---@param service     string  The AWS service the request will use
+---@param body_digest string  The SHA256 hex-encoded digest of the request body
+---@param timestamp   integer The current time as a Unix timestamp
+function _M.aws_set_headers_detailed(host, uri, region, service, body_digest, timestamp)
+  local creds = get_credentials()
+
+  local auth = get_authorization(creds, timestamp, region, service, host, uri, body_digest)
 
   ngx.req.set_header('Authorization', auth)
   ngx.req.set_header('Host', host)
   ngx.req.set_header('x-amz-date', get_iso8601_basic(timestamp))
-end
-
-function _M.s3_set_headers(host, uri)
-  _M.aws_set_headers(host, uri)
-  ngx.req.set_header('x-amz-content-sha256', get_sha256_digest(ngx.var.request_body))
+  ngx.req.set_header('x-amz-content-sha256', body_digest)
 end
 
 return _M

--- a/t/basic_signing.t
+++ b/t/basic_signing.t
@@ -1,0 +1,86 @@
+use Test::Nginx::Socket 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== Test Unsigned-Payload Signing:
+--- main_config
+env AWS_ACCESS_KEY_ID=XXXXX;
+env AWS_SECRET_ACCESS_KEY=YYYYY;
+
+--- http_config
+    init_worker_by_lua_block {
+        print("init")
+    }
+
+--- config
+    location = /t {
+        access_by_lua_block {
+            local aws = require('resty.aws-signature')
+            aws.aws_set_headers_detailed('example.com', ngx.var.uri, 'us-east-1', 's3', 'UNSIGNED-PAYLOAD', 1732156539)
+        }
+
+        content_by_lua_block {
+            -- Dump all the request headers and turn them into response headers
+            local h, err = ngx.req.get_headers()
+
+            for k, v in pairs(h) do
+                ngx.header[k] = v
+            end
+
+            ngx.print('ok')
+        }
+    }
+--- request
+GET /t
+--- response_body chomp
+ok
+--- no_error_log
+[error]
+--- response_headers
+Authorization: AWS4-HMAC-SHA256 Credential=XXXXX/20241121/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=158e1fc160922a2b29b75ff169866a0f806bad69f85d71f673681fa2de8b4eec
+Host: example.com
+x-amz-date: 20241121T023539Z
+x-amz-content-sha256: UNSIGNED-PAYLOAD
+
+
+=== Test Signed-Payload Signing:
+--- main_config
+env AWS_ACCESS_KEY_ID=XXXXX;
+env AWS_SECRET_ACCESS_KEY=YYYYY;
+
+--- http_config
+    init_worker_by_lua_block {
+        print("init")
+    }
+
+--- config
+    location = /t {
+        access_by_lua_block {
+            local aws = require('resty.aws-signature')
+            aws.aws_set_headers_detailed('example.com', ngx.var.uri, 'us-east-1', 's3', 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c', 1732156539)
+        }
+
+        content_by_lua_block {
+            -- Dump all the request headers and turn them into response headers
+            local h, err = ngx.req.get_headers()
+
+            for k, v in pairs(h) do
+                ngx.header[k] = v
+            end
+
+            ngx.print('ok')
+        }
+    }
+--- request
+GET /t
+--- response_body chomp
+ok
+--- no_error_log
+[error]
+--- response_headers
+Authorization: AWS4-HMAC-SHA256 Credential=XXXXX/20241121/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=14e366e10d1fcea41a6ef10afee718f01661561c4c4e888327b12d34c81f6dac
+Host: example.com
+x-amz-date: 20241121T023539Z
+x-amz-content-sha256: b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c


### PR DESCRIPTION
* We now support non AWS hosts
* And we can utilize `UNSIGNED-PAYLOAD` signing to avoid reading the entire body

BREAKING CHANGE: This modifies the function signature of aws_set_headers() and adds additional module functions