### PR TITLE
feat: Return a table of headers instead of setting them ourselves

### DIFF
--- a/t/basic_signing.t
+++ b/t/basic_signing.t
@@ -4,27 +4,18 @@ run_tests();
 
 __DATA__
 
-=== Test Unsigned-Payload Signing:
+=== Test Unsigned-Payload:
 --- main_config
 env AWS_ACCESS_KEY_ID=XXXXX;
 env AWS_SECRET_ACCESS_KEY=YYYYY;
 
---- http_config
-    init_worker_by_lua_block {
-        print("init")
-    }
-
 --- config
     location = /t {
-        access_by_lua_block {
-            local aws = require('resty.aws-signature')
-            aws.aws_set_headers_detailed('example.com', ngx.var.uri, 'us-east-1', 's3', 'UNSIGNED-PAYLOAD', 1732156539)
-        }
-
         content_by_lua_block {
-            -- Dump all the request headers and turn them into response headers
-            local h, err = ngx.req.get_headers()
+            local aws = require('resty.aws-signature')
 
+            -- Calculate the headers and stuff them into the response
+            h = aws.aws_signed_headers_detailed('example.com', '/foo/bar', 'us-east-1', 's3', 'UNSIGNED-PAYLOAD', 1732156539)
             for k, v in pairs(h) do
                 ngx.header[k] = v
             end
@@ -39,33 +30,24 @@ ok
 --- no_error_log
 [error]
 --- response_headers
-Authorization: AWS4-HMAC-SHA256 Credential=XXXXX/20241121/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=158e1fc160922a2b29b75ff169866a0f806bad69f85d71f673681fa2de8b4eec
+Authorization: AWS4-HMAC-SHA256 Credential=XXXXX/20241121/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=75f899ff89e8248368c29bba4020d006613aa557ed0b492af19f118b8c7d9f65
 Host: example.com
 x-amz-date: 20241121T023539Z
 x-amz-content-sha256: UNSIGNED-PAYLOAD
 
 
-=== Test Signed-Payload Signing:
+=== Test Signed-Payload:
 --- main_config
 env AWS_ACCESS_KEY_ID=XXXXX;
 env AWS_SECRET_ACCESS_KEY=YYYYY;
 
---- http_config
-    init_worker_by_lua_block {
-        print("init")
-    }
-
 --- config
     location = /t {
-        access_by_lua_block {
-            local aws = require('resty.aws-signature')
-            aws.aws_set_headers_detailed('example.com', ngx.var.uri, 'us-east-1', 's3', 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c', 1732156539)
-        }
-
         content_by_lua_block {
-            -- Dump all the request headers and turn them into response headers
-            local h, err = ngx.req.get_headers()
+            local aws = require('resty.aws-signature')
 
+            -- Calculate the headers and stuff them into the response
+            h = aws.aws_signed_headers_detailed('example.com', '/foo/bar', 'us-east-1', 's3', 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c', 1732156539)
             for k, v in pairs(h) do
                 ngx.header[k] = v
             end
@@ -80,7 +62,7 @@ ok
 --- no_error_log
 [error]
 --- response_headers
-Authorization: AWS4-HMAC-SHA256 Credential=XXXXX/20241121/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=14e366e10d1fcea41a6ef10afee718f01661561c4c4e888327b12d34c81f6dac
+Authorization: AWS4-HMAC-SHA256 Credential=XXXXX/20241121/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=edb2f1da721ae556bed1dbec0e9345241451d49c5ba2be0f89e7d08f8f32728d
 Host: example.com
 x-amz-date: 20241121T023539Z
 x-amz-content-sha256: b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c


### PR DESCRIPTION
This allows the library to be used for LUA subrequests as well as native nginx proxy_pass requests

BREAKING CHANGE: The functions are renamed and the signature changed to return a table instead of setting the headers for you