### PR TITLE
feat: Allow the request method to be overridden

### DIFF
--- a/t/basic_signing.t
+++ b/t/basic_signing.t
@@ -15,7 +15,7 @@ env AWS_SECRET_ACCESS_KEY=YYYYY;
             local aws = require('resty.aws-signature')
 
             -- Calculate the headers and stuff them into the response
-            h = aws.aws_signed_headers_detailed('example.com', '/foo/bar', 'us-east-1', 's3', 'UNSIGNED-PAYLOAD', 1732156539)
+            h = aws.aws_signed_headers_detailed('GET', 'example.com', '/foo/bar', 'us-east-1', 's3', 'UNSIGNED-PAYLOAD', 1732156539)
             for k, v in pairs(h) do
                 ngx.header[k] = v
             end
@@ -47,7 +47,7 @@ env AWS_SECRET_ACCESS_KEY=YYYYY;
             local aws = require('resty.aws-signature')
 
             -- Calculate the headers and stuff them into the response
-            h = aws.aws_signed_headers_detailed('example.com', '/foo/bar', 'us-east-1', 's3', 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c', 1732156539)
+            h = aws.aws_signed_headers_detailed('GET', 'example.com', '/foo/bar', 'us-east-1', 's3', 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c', 1732156539)
             for k, v in pairs(h) do
                 ngx.header[k] = v
             end
@@ -66,3 +66,67 @@ Authorization: AWS4-HMAC-SHA256 Credential=XXXXX/20241121/us-east-1/s3/aws4_requ
 Host: example.com
 x-amz-date: 20241121T023539Z
 x-amz-content-sha256: b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+
+
+=== Test HEAD:
+--- main_config
+env AWS_ACCESS_KEY_ID=XXXXX;
+env AWS_SECRET_ACCESS_KEY=YYYYY;
+
+--- config
+    location = /t {
+        content_by_lua_block {
+            local aws = require('resty.aws-signature')
+
+            -- Calculate the headers and stuff them into the response
+            h = aws.aws_signed_headers_detailed('HEAD', 'example.com', '/foo/bar', 'us-east-1', 's3', 'UNSIGNED-PAYLOAD', 1732156539)
+            for k, v in pairs(h) do
+                ngx.header[k] = v
+            end
+
+            ngx.print('ok')
+        }
+    }
+--- request
+HEAD /t
+--- response_body chomp
+
+--- no_error_log
+[error]
+--- response_headers
+Authorization: AWS4-HMAC-SHA256 Credential=XXXXX/20241121/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=7d0db7f2cf3c8f4f5c4dfafb8771c058a8a7f24d2ea8177a6bcc95d1edc297f0
+Host: example.com
+x-amz-date: 20241121T023539Z
+x-amz-content-sha256: UNSIGNED-PAYLOAD
+
+
+=== Test HEAD overridden to a GET for signature (proxy_cache_convert_head):
+--- main_config
+env AWS_ACCESS_KEY_ID=XXXXX;
+env AWS_SECRET_ACCESS_KEY=YYYYY;
+
+--- config
+    location = /t {
+        content_by_lua_block {
+            local aws = require('resty.aws-signature')
+
+            -- Calculate the headers and stuff them into the response
+            h = aws.aws_signed_headers_detailed('GET', 'example.com', '/foo/bar', 'us-east-1', 's3', 'UNSIGNED-PAYLOAD', 1732156539)
+            for k, v in pairs(h) do
+                ngx.header[k] = v
+            end
+
+            ngx.print('ok')
+        }
+    }
+--- request
+HEAD /t
+--- response_body chomp
+
+--- no_error_log
+[error]
+--- response_headers
+Authorization: AWS4-HMAC-SHA256 Credential=XXXXX/20241121/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=75f899ff89e8248368c29bba4020d006613aa557ed0b492af19f118b8c7d9f65
+Host: example.com
+x-amz-date: 20241121T023539Z
+x-amz-content-sha256: UNSIGNED-PAYLOAD


### PR DESCRIPTION
When nginx converts HEAD requests to GET requests via proxy_cache_convert_head, the request_method variable isn't changed. Thus users using that setting (which is on by default) will need to use logic in LUA to override the method value manually. Otherwise the signature will not match on the server